### PR TITLE
Fix some bugs

### DIFF
--- a/python_api/coinut_api.py
+++ b/python_api/coinut_api.py
@@ -303,11 +303,11 @@ class CoinutAPI():
     def request(self, api, content = {}):
         url = 'https://api.coinut.com'
         content["request"] = api
-        content["nonce"] = random.randint(1, 4294967200)
+        content["nonce"] = random.randint(1, 16777215)
         content = json.dumps(content)
         headers = {}
         if self.api_key is not None and self.user is not None:
-            sig = hmac.new(self.api_key, msg=content,
+            sig = hmac.new(self.api_key.encode('utf-8'), msg=content.encode('utf-8'),
                            digestmod=hashlib.sha256).hexdigest()
             headers = {'X-USER': self.user, "X-SIGNATURE": sig}
 


### PR DESCRIPTION
Have to encode the key and msg for generating the signature, according to [here](https://github.com/coinut/api/wiki/REST-API#authentication)

Incorrect generation of the nonce, and usually leads to a "INVALID NONCE" in return. According to [here](https://github.com/coinut/api/wiki/Websocket-API#nonce), the correct range should be [1, 16777215]

test with python=3.8